### PR TITLE
Enhance Wayland EGL display initialization and error handling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
 
         nativeBuildInputs = with pkgs; [
           pkg-config
+          makeWrapper
         ];
 
         buildInputs = with pkgs; [
@@ -31,6 +32,14 @@
           mesa
           xorg.libX11
         ];
+
+        postFixup = ''
+          wrapProgram $out/bin/hexecute \
+            --prefix __EGL_VENDOR_LIBRARY_DIRS : "/run/opengl-driver/share/glvnd/egl_vendor.d" \
+            --prefix __EGL_VENDOR_LIBRARY_DIRS : "${pkgs.mesa}/share/glvnd/egl_vendor.d" \
+            --prefix LIBGL_DRIVERS_PATH : "/run/opengl-driver/lib/dri" \
+            --prefix LIBGL_DRIVERS_PATH : "${pkgs.mesa}/lib/dri"
+        '';
 
         meta = {
           description = "Launch apps by casting spells! 🪄";

--- a/pkg/wayland/wayland.c
+++ b/pkg/wayland/wayland.c
@@ -190,6 +190,48 @@ void add_registry_listener(struct wl_registry *registry) {
   wl_registry_add_listener(registry, &registry_listener, NULL);
 }
 
+EGLDisplay get_egl_display(struct wl_display *display) {
+  EGLDisplay egl_display = EGL_NO_DISPLAY;
+
+#if defined(EGL_VERSION_1_5)
+  egl_display = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, display, NULL);
+#endif
+
+  if (egl_display == EGL_NO_DISPLAY) {
+    PFNEGLGETPLATFORMDISPLAYPROC get_platform_display =
+        (PFNEGLGETPLATFORMDISPLAYPROC)eglGetProcAddress(
+            "eglGetPlatformDisplay");
+    if (get_platform_display) {
+      egl_display =
+          get_platform_display(EGL_PLATFORM_WAYLAND_KHR, display, NULL);
+    }
+  }
+
+  if (egl_display == EGL_NO_DISPLAY) {
+    PFNEGLGETPLATFORMDISPLAYEXTPROC get_platform_display_ext =
+        (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress(
+            "eglGetPlatformDisplayEXT");
+    if (get_platform_display_ext) {
+      egl_display =
+          get_platform_display_ext(EGL_PLATFORM_WAYLAND_EXT, display, NULL);
+    }
+  }
+
+  if (egl_display == EGL_NO_DISPLAY) {
+    egl_display = eglGetDisplay((EGLNativeDisplayType)display);
+  }
+
+  if (egl_display == EGL_NO_DISPLAY) {
+    egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  }
+
+  return egl_display;
+}
+
+EGLint get_egl_error(void) {
+  return eglGetError();
+}
+
 struct wl_surface *surface_global = NULL;
 
 struct zwlr_layer_surface_v1 *create_layer_surface(struct wl_surface *surface) {

--- a/pkg/wayland/wayland.go
+++ b/pkg/wayland/wayland.go
@@ -98,9 +98,10 @@ func (w *WaylandWindow) initEGL() error {
 		return fmt.Errorf("failed to create EGL window")
 	}
 
-	w.eglDisplay = C.eglGetDisplay(C.EGLNativeDisplayType(w.display))
+	w.eglDisplay = C.get_egl_display(w.display)
 	if w.eglDisplay == C.EGLDisplay(C.EGL_NO_DISPLAY) {
-		return fmt.Errorf("failed to get EGL display")
+		errCode := C.get_egl_error()
+		return fmt.Errorf("failed to get EGL display (eglGetError=0x%X)", uint32(errCode))
 	}
 
 	var major, minor C.EGLint

--- a/pkg/wayland/wayland.h
+++ b/pkg/wayland/wayland.h
@@ -4,10 +4,21 @@
 #include "tablet-v2.h"
 #include "wlr-layer-shell-client.h"
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include <stdlib.h>
 #include <wayland-client.h>
 #include <wayland-egl.h>
 #include <xkbcommon/xkbcommon.h>
+
+#ifndef EGL_PLATFORM_WAYLAND_KHR
+#define EGL_PLATFORM_WAYLAND_KHR 0x31D8
+#endif
+#ifndef EGL_PLATFORM_WAYLAND_EXT
+#define EGL_PLATFORM_WAYLAND_EXT 0x31D8
+#endif
+
+EGLDisplay get_egl_display(struct wl_display *display);
+EGLint get_egl_error(void);
 
 void layer_surface_configure(void *data, struct zwlr_layer_surface_v1 *surface,
                              uint32_t serial, uint32_t width, uint32_t height);


### PR DESCRIPTION
This PR improves EGL display initialization and error handling for Wayland support, and updates the build process to ensure correct OpenGL driver paths are set at runtime.

**Wayland/EGL Improvements:**

* Added a new `get_egl_display` function in `wayland.c` (with declarations in `wayland.h`) that attempts multiple EGL display acquisition methods, increasing compatibility across different EGL implementations. (`pkg/wayland/wayland.c`, `pkg/wayland/wayland.h`) [[1]](diffhunk://#diff-1277cb7e34b15bffcd83865efaf2cdf133d183945855278deb06412e3edfdf98R193-R234) [[2]](diffhunk://#diff-633b2c3e72e107b505891522bfeba8482e40cb0535349240d615158cffbcbad6R7-R22)
* Introduced a `get_egl_error` function for retrieving EGL error codes, and updated Go code to report detailed EGL initialization errors using this function. (`pkg/wayland/wayland.c`, `pkg/wayland/wayland.h`, `pkg/wayland/wayland.go`) [[1]](diffhunk://#diff-1277cb7e34b15bffcd83865efaf2cdf133d183945855278deb06412e3edfdf98R193-R234) [[2]](diffhunk://#diff-633b2c3e72e107b505891522bfeba8482e40cb0535349240d615158cffbcbad6R7-R22) [[3]](diffhunk://#diff-1d5f0914582f42ffaeedd19c42d851d5adfdee4db31f27becb7af39d4ff0a11cL101-R104)

**Build System (Nix) Enhancements:**

* Added `makeWrapper` to `nativeBuildInputs` and a `postFixup` step in `flake.nix` to wrap the `hexecute` binary, ensuring the correct OpenGL driver paths are set via environment variables at runtime for better graphics compatibility. (`flake.nix`) [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R23) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R36-R43)

**Header and Compatibility Updates:**

* Included `<EGL/eglext.h>` and defined missing EGL platform macros in `wayland.h` to ensure the code compiles and runs reliably across different systems. (`pkg/wayland/wayland.h`)